### PR TITLE
Show pinned repositories first in the Projects page

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ pnpm run preview
 
 ## Environment Variables
 
-To fetch information about my projects, the site uses Octokit for querying the GitHub REST API.
-If the `GITHUB_TOKEN` environment variable is set, it is passed to Octokit for authentication
-(authenticated requests have more generous rate limits).
+To fetch information about my projects, the site uses Octokit for querying the GitHub GraphQL API,
+which requires a valid GitHub token.
+This token must be specified using the `GITHUB_TOKEN` environment variable.
 
 Environment variables can be specified in a `.env` file.
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@iconify/vue": "^5.0.0",
     "@nanostores/persistent": "^1.1.0",
     "@nanostores/vue": "^1.0.1",
-    "@octokit/rest": "^22.0.0",
+    "@octokit/graphql": "^9.0.1",
     "@octokit/types": "^14.1.0",
     "astro": "^5.11.1",
     "chroma-js": "^3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,9 @@ importers:
       '@nanostores/vue':
         specifier: ^1.0.1
         version: 1.0.1(nanostores@1.0.1)(vue@3.5.17(typescript@5.8.3))
-      '@octokit/rest':
-        specifier: ^22.0.0
-        version: 22.0.0
+      '@octokit/graphql':
+        specifier: ^9.0.1
+        version: 9.0.1
       '@octokit/types':
         specifier: ^14.1.0
         version: 14.1.0
@@ -617,14 +617,6 @@ packages:
       '@vue/devtools-api':
         optional: true
 
-  '@octokit/auth-token@6.0.0':
-    resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
-    engines: {node: '>= 20'}
-
-  '@octokit/core@7.0.3':
-    resolution: {integrity: sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==}
-    engines: {node: '>= 20'}
-
   '@octokit/endpoint@11.0.0':
     resolution: {integrity: sha512-hoYicJZaqISMAI3JfaDr1qMNi48OctWuOih1m80bkYow/ayPw6Jj52tqWJ6GEoFTk1gBqfanSoI1iY99Z5+ekQ==}
     engines: {node: '>= 20'}
@@ -636,34 +628,12 @@ packages:
   '@octokit/openapi-types@25.1.0':
     resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
 
-  '@octokit/plugin-paginate-rest@13.1.1':
-    resolution: {integrity: sha512-q9iQGlZlxAVNRN2jDNskJW/Cafy7/XE52wjZ5TTvyhyOD904Cvx//DNyoO3J/MXJ0ve3rPoNWKEg5iZrisQSuw==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      '@octokit/core': '>=6'
-
-  '@octokit/plugin-request-log@6.0.0':
-    resolution: {integrity: sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      '@octokit/core': '>=6'
-
-  '@octokit/plugin-rest-endpoint-methods@16.0.0':
-    resolution: {integrity: sha512-kJVUQk6/dx/gRNLWUnAWKFs1kVPn5O5CYZyssyEoNYaFedqZxsfYs7DwI3d67hGz4qOwaJ1dpm07hOAD1BXx6g==}
-    engines: {node: '>= 20'}
-    peerDependencies:
-      '@octokit/core': '>=6'
-
   '@octokit/request-error@7.0.0':
     resolution: {integrity: sha512-KRA7VTGdVyJlh0cP5Tf94hTiYVVqmt2f3I6mnimmaVz4UG3gQV/k4mDJlJv3X67iX6rmN7gSHCF8ssqeMnmhZg==}
     engines: {node: '>= 20'}
 
   '@octokit/request@10.0.3':
     resolution: {integrity: sha512-V6jhKokg35vk098iBqp2FBKunk3kMTXlmq+PtbV9Gl3TfskWlebSofU9uunVKhUN7xl+0+i5vt0TGTG8/p/7HA==}
-    engines: {node: '>= 20'}
-
-  '@octokit/rest@22.0.0':
-    resolution: {integrity: sha512-z6tmTu9BTnw51jYGulxrlernpsQYXpui1RK21vmXn8yF5bp6iX16yfTtJYGK5Mh1qDkvDOmp2n8sRMcQmR8jiA==}
     engines: {node: '>= 20'}
 
   '@octokit/types@14.1.0':
@@ -1063,9 +1033,6 @@ packages:
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  before-after-hook@4.0.0:
-    resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -2990,18 +2957,6 @@ snapshots:
       nanostores: 1.0.1
       vue: 3.5.17(typescript@5.8.3)
 
-  '@octokit/auth-token@6.0.0': {}
-
-  '@octokit/core@7.0.3':
-    dependencies:
-      '@octokit/auth-token': 6.0.0
-      '@octokit/graphql': 9.0.1
-      '@octokit/request': 10.0.3
-      '@octokit/request-error': 7.0.0
-      '@octokit/types': 14.1.0
-      before-after-hook: 4.0.0
-      universal-user-agent: 7.0.3
-
   '@octokit/endpoint@11.0.0':
     dependencies:
       '@octokit/types': 14.1.0
@@ -3015,20 +2970,6 @@ snapshots:
 
   '@octokit/openapi-types@25.1.0': {}
 
-  '@octokit/plugin-paginate-rest@13.1.1(@octokit/core@7.0.3)':
-    dependencies:
-      '@octokit/core': 7.0.3
-      '@octokit/types': 14.1.0
-
-  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.3)':
-    dependencies:
-      '@octokit/core': 7.0.3
-
-  '@octokit/plugin-rest-endpoint-methods@16.0.0(@octokit/core@7.0.3)':
-    dependencies:
-      '@octokit/core': 7.0.3
-      '@octokit/types': 14.1.0
-
   '@octokit/request-error@7.0.0':
     dependencies:
       '@octokit/types': 14.1.0
@@ -3040,13 +2981,6 @@ snapshots:
       '@octokit/types': 14.1.0
       fast-content-type-parse: 3.0.0
       universal-user-agent: 7.0.3
-
-  '@octokit/rest@22.0.0':
-    dependencies:
-      '@octokit/core': 7.0.3
-      '@octokit/plugin-paginate-rest': 13.1.1(@octokit/core@7.0.3)
-      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.3)
-      '@octokit/plugin-rest-endpoint-methods': 16.0.0(@octokit/core@7.0.3)
 
   '@octokit/types@14.1.0':
     dependencies:
@@ -3546,8 +3480,6 @@ snapshots:
   base-64@1.0.0: {}
 
   base64-js@1.5.1: {}
-
-  before-after-hook@4.0.0: {}
 
   bindings@1.5.0:
     dependencies:

--- a/src/components/RepoCard.vue
+++ b/src/components/RepoCard.vue
@@ -51,10 +51,13 @@
           >
             <span>
               <span :class="$style.repoTitleText">{{ repo.owner }}/{{ repo.name }}</span>
-              <span :class="$style.repoTitleExternalLinkWrapper">
+              <span
+                v-if="repo.pinned"
+                :class="$style.repoTitlePinWrapper"
+              >
                 <Icon
-                  icon="lucide:external-link"
-                  :class="$style.repoTitleExternalLink"
+                  icon="mynaui:pin"
+                  :class="$style.repoTitlePin"
                 />
               </span>
             </span>
@@ -128,13 +131,13 @@
     text-decoration: underline;
   }
 
-  .repoTitleExternalLinkWrapper {
+  .repoTitlePinWrapper {
     white-space: nowrap;
   }
 
-  .repoTitleExternalLink {
-    font-size: 0.8em;
-    margin-inline-start: 0.25em;
+  .repoTitlePin {
+    font-size: 0.9em;
+    margin-inline-start: 0.375em;
   }
 
   .repoStatusCluster {

--- a/src/components/RepoCard.vue
+++ b/src/components/RepoCard.vue
@@ -13,19 +13,19 @@
   const smallStats = [
     {
       icon: "lucide:star",
-      label: (repo.stargazers_count ?? 0).toString(),
+      label: repo.stargazers.toString(),
     },
     {
       icon: "lucide:eye",
-      label: (repo.watchers_count ?? 0).toString(),
+      label: repo.watchers.toString(),
     },
     {
       icon: "lucide:git-fork",
-      label: (repo.forks_count ?? 0).toString(),
+      label: repo.forks.toString(),
     },
     {
       icon: "lucide:scale",
-      label: repo.license?.name ?? "Unlicensed",
+      label: repo.license ?? "Unlicensed",
     },
   ];
 </script>
@@ -42,7 +42,7 @@
       <Cluster :class="$style.cardHeader">
         <a
           :class="$style.repoTitle"
-          :href="repo.html_url"
+          :href="repo.url"
           target="_blank"
         >
           <IconText
@@ -50,7 +50,7 @@
             iconSize="2em"
           >
             <span>
-              <span :class="$style.repoTitleText">{{ repo.owner.login }}/{{ repo.name }}</span>
+              <span :class="$style.repoTitleText">{{ repo.owner }}/{{ repo.name }}</span>
               <span :class="$style.repoTitleExternalLinkWrapper">
                 <Icon
                   icon="lucide:external-link"
@@ -63,7 +63,7 @@
 
         <Cluster :class="$style.repoStatusCluster">
           <Badge
-            v-if="repo.owner.login !== 'dixslyf'"
+            v-if="repo.owner !== 'dixslyf'"
             fg="var(--repo-collaborator-fg)"
             bg="var(--repo-collaborator-bg)"
             >Collaborator</Badge

--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -1,31 +1,57 @@
-import type { Endpoints } from "@octokit/types";
-import { Octokit } from "@octokit/rest";
+import { graphql } from "@octokit/graphql";
 import { DateTime } from "luxon";
 
-type FilteredRepoAttributes =
-  | "stargazers_count"
-  | "watchers_count"
-  | "forks_count"
-  | "license"
-  | "html_url"
-  | "owner"
-  | "name"
-  | "archived"
-  | "description"
-  | "homepage";
-
-type RawRepoInfo = Endpoints["GET /users/{username}/repos"]["response"]["data"][number];
-
-export type RepoInfo = Pick<RawRepoInfo, FilteredRepoAttributes> & {
-  languages: Endpoints["GET /repos/{owner}/{repo}/languages"]["response"]["data"];
+// Ref: https://github.com/octokit/graphql-schema/blob/main/schema.d.ts
+type QueryResponse = {
+  repositories: {
+    nodes: {
+      stargazerCount: number;
+      watchers: { totalCount: number };
+      forkCount: number;
+      languages: {
+        edges:
+          | {
+              node: {
+                name: string;
+                color: string;
+              };
+              size: number;
+            }[]
+          | null;
+      } | null;
+      licenseInfo: { name: string } | null;
+      url: string;
+      owner: { login: string };
+      name: string;
+      isArchived: boolean;
+      description: string | null;
+      homepageUrl: string | null;
+    }[];
+  };
 };
 
-export const DIXSLYF_ID = 56017218;
+type RepoInfo = {
+  stargazers: number;
+  watchers: number;
+  forks: number;
+  license: string | null;
+  url: string;
+  owner: string;
+  name: string;
+  archived: boolean;
+  description: string | null;
+  homepage: string | null;
+  languages: {
+    [key: string]: number;
+  } | null;
+};
+
+export const DIXSLYF_LOGIN = "dixslyf";
 
 export function sortGitHubRepos(repoA: RepoInfo, repoB: RepoInfo): number {
   // If A has more stars than B, A should be before B, and vice versa.
-  const repoAStars = repoA.stargazers_count ?? 0;
-  const repoBStars = repoB.stargazers_count ?? 0;
+  const repoAStars = repoA.stargazers ?? 0;
+  const repoBStars = repoB.stargazers ?? 0;
   const starsDiff = repoAStars - repoBStars;
   if (starsDiff !== 0) {
     return -starsDiff;
@@ -46,11 +72,11 @@ export function sortGitHubRepos(repoA: RepoInfo, repoB: RepoInfo): number {
   // Same archival status at this point.
 
   // Prioritise repos that I own.
-  if (repoA.owner.id === DIXSLYF_ID && repoB.owner.id !== DIXSLYF_ID) {
+  if (repoA.owner === DIXSLYF_LOGIN && repoB.owner !== DIXSLYF_LOGIN) {
     return -1;
   }
 
-  if (repoB.owner.id === DIXSLYF_ID && repoA.owner.id !== DIXSLYF_ID) {
+  if (repoB.owner === DIXSLYF_LOGIN && repoA.owner !== DIXSLYF_LOGIN) {
     return 1;
   }
 
@@ -61,45 +87,63 @@ export async function fetchGitHubProjects(): Promise<{
   timestamp: string;
   repos: RepoInfo[];
 }> {
-  const octokit = new Octokit({
-    userAgent: "dixslyf-website",
-    request: {
-      fetch,
+  const queryGitHub = graphql.defaults({
+    headers: {
+      authorization: `token ${import.meta.env.GITHUB_TOKEN}`,
     },
-    auth: import.meta.env.GITHUB_TOKEN,
   });
 
-  const res = await octokit.rest.repos.listForUser({
-    username: "dixslyf",
-    type: "all",
-  });
+  const res = await queryGitHub<{ repositoryOwner: QueryResponse }>(`{
+    repositoryOwner(login: "dixslyf") {
+      repositories(ownerAffiliations: [OWNER, COLLABORATOR], visibility: PUBLIC, isFork: false, first: 100) {
+        nodes {
+          stargazerCount
+          watchers { totalCount }
+          forkCount
+          languages(first: 10) {
+            edges {
+              node { 
+                name
+                color
+              }
+              size
+            }
+          }
+          licenseInfo { name }
+          url
+          owner { login }
+          name
+          isArchived
+          description
+          homepageUrl
+        }
+      }
+    }
+  }`);
 
-  // Filter out forks and unneeded attributes.
-  const rawRepos = res.data
-    .filter((repo) => !repo.fork)
-    .map((repo) => ({
-      stargazers_count: repo.stargazers_count,
-      watchers_count: repo.watchers_count,
-      forks_count: repo.forks_count,
-      license: repo.license,
-      html_url: repo.html_url,
-      owner: repo.owner,
-      name: repo.name,
-      archived: repo.archived,
-      description: repo.description,
-      homepage: repo.homepage,
-    }));
-
-  // Fetch languages.
-  const repoPromises = rawRepos.map(async (repo) => {
-    const res = await octokit.rest.repos.listLanguages({
-      owner: repo.owner.login,
-      repo: repo.name,
-    });
-    return { ...repo, languages: res.data } satisfies RepoInfo;
-  });
-
-  const repos = (await Promise.all(repoPromises)).sort(sortGitHubRepos);
+  // Transform response into the return type.
+  const repos: RepoInfo[] = res.repositoryOwner.repositories.nodes
+    .map(
+      (rawRepo) =>
+        ({
+          stargazers: rawRepo.stargazerCount,
+          watchers: rawRepo.watchers.totalCount,
+          forks: rawRepo.forkCount,
+          license: rawRepo.licenseInfo?.name ?? null,
+          url: rawRepo.url,
+          owner: rawRepo.owner.login,
+          name: rawRepo.name,
+          archived: rawRepo.isArchived,
+          description: rawRepo.description,
+          homepage: rawRepo.homepageUrl,
+          languages: rawRepo.languages?.edges
+            ? Object.fromEntries(
+                rawRepo.languages.edges.map((langInfo) => [langInfo.node.name, langInfo.size]),
+              )
+            : null,
+        }) satisfies RepoInfo,
+    )
+    .sort(sortGitHubRepos);
 
   const now = DateTime.utc();
   return { timestamp: now.toISO(), repos };

--- a/src/utils/projects.ts
+++ b/src/utils/projects.ts
@@ -2,14 +2,15 @@ import { graphql } from "@octokit/graphql";
 import { DateTime } from "luxon";
 
 // Ref: https://github.com/octokit/graphql-schema/blob/main/schema.d.ts
-type QueryResponse = {
-  repositoryOwner: {
+type ReposResponse = {
+  user: {
     repositories: {
       pageInfo: {
         hasNextPage: boolean;
         endCursor: string | null;
       };
       nodes: {
+        id: string;
         stargazerCount: number;
         watchers: { totalCount: number };
         forkCount: number;
@@ -36,7 +37,23 @@ type QueryResponse = {
   };
 };
 
+type PinnedReposResponse = {
+  user: {
+    pinnedItems: {
+      pageInfo: {
+        hasNextPage: boolean;
+        endCursor: string | null;
+      };
+      nodes: {
+        __typename: string;
+        id: string;
+      }[];
+    };
+  };
+};
+
 type RepoInfo = {
+  id: string;
   stargazers: number;
   watchers: number;
   forks: number;
@@ -47,6 +64,7 @@ type RepoInfo = {
   archived: boolean;
   description: string | null;
   homepage: string | null;
+  pinned: boolean;
   languages: {
     [key: string]: number;
   } | null;
@@ -60,29 +78,31 @@ const queryGitHub = graphql.defaults({
   },
 });
 
-async function queryRepos(): Promise<QueryResponse["repositoryOwner"]["repositories"]["nodes"]> {
+async function queryRepos(): Promise<Omit<RepoInfo, "pinned">[]> {
   let hasNextPage = true;
   let cursor = null;
-  const repos = [];
+  const rawRepos = [];
   let reqCount = 0;
 
   // `reqCount` is there as a safeguard to prevent spamming requests
   // in case something unexpectedly goes wrong. I'll probably never reach
   // 1,000 public repositories.
   while (hasNextPage && reqCount < 10) {
-    const res: QueryResponse = await queryGitHub<QueryResponse>(`
+    const res: ReposResponse = await queryGitHub<ReposResponse>(
+      `
       query repos($after: String) {
-        repositoryOwner(login: "dixslyf") {
+        user(login: "dixslyf") {
           repositories(ownerAffiliations: [OWNER, COLLABORATOR], visibility: PUBLIC, isFork: false, first: 100, after: $after) {
             pageInfo {
               hasNextPage
               endCursor
             }
             nodes {
+              id
               stargazerCount
               watchers { totalCount }
               forkCount
-              languages(first: 10) {
+              languages(first: 100) {
                 edges {
                   node {
                     name
@@ -107,16 +127,89 @@ async function queryRepos(): Promise<QueryResponse["repositoryOwner"]["repositor
       },
     );
 
-    repos.push(...res.repositoryOwner.repositories.nodes);
-    hasNextPage = res.repositoryOwner.repositories.pageInfo.hasNextPage;
-    cursor = res.repositoryOwner.repositories.pageInfo.endCursor;
+    rawRepos.push(...res.user.repositories.nodes);
+    hasNextPage = res.user.repositories.pageInfo.hasNextPage;
+    cursor = res.user.repositories.pageInfo.endCursor;
     reqCount += 1;
   }
 
-  return repos;
+  return rawRepos.map(
+    (rawRepo) =>
+      ({
+        id: rawRepo.id,
+        stargazers: rawRepo.stargazerCount,
+        watchers: rawRepo.watchers.totalCount,
+        forks: rawRepo.forkCount,
+        license: rawRepo.licenseInfo?.name ?? null,
+        url: rawRepo.url,
+        owner: rawRepo.owner.login,
+        name: rawRepo.name,
+        archived: rawRepo.isArchived,
+        description: rawRepo.description,
+        homepage: rawRepo.homepageUrl,
+        languages: rawRepo.languages?.edges
+          ? Object.fromEntries(
+              rawRepo.languages.edges.map((langInfo) => [langInfo.node.name, langInfo.size]),
+            )
+          : null,
+      }) satisfies Omit<RepoInfo, "pinned">,
+  );
 }
 
-export function sortGitHubRepos(repoA: RepoInfo, repoB: RepoInfo): number {
+async function queryPinnedRepos(): Promise<Set<string>> {
+  let hasNextPage = true;
+  let cursor = null;
+  const pinnedRepos = [];
+  let reqCount = 0;
+
+  while (hasNextPage && reqCount < 10) {
+    const res: PinnedReposResponse = await queryGitHub<PinnedReposResponse>(
+      `
+      query pinnedRepos($after: String) {
+        user(login: "dixslyf") {
+          pinnedItems(first: 100, after: $after) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
+            nodes {
+              __typename
+              ... on Repository {
+                id
+              }
+            }
+          }
+        }
+      }`,
+      {
+        after: cursor,
+      },
+    );
+
+    pinnedRepos.push(...res.user.pinnedItems.nodes);
+    hasNextPage = res.user.pinnedItems.pageInfo.hasNextPage;
+    cursor = res.user.pinnedItems.pageInfo.endCursor;
+    reqCount += 1;
+  }
+
+  return new Set(pinnedRepos.map((node) => node.id));
+}
+
+function sortGitHubRepos(repoA: RepoInfo, repoB: RepoInfo): number {
+  // Check pinned status.
+
+  // A is pinned, but not B.
+  if (repoA.pinned && !repoB.pinned) {
+    return -1;
+  }
+
+  // A is pinned, but not B.
+  if (!repoA.pinned && repoB.pinned) {
+    return 1;
+  }
+
+  // Pin statuses are equal at this point.
+
   // If A has more stars than B, A should be before B, and vice versa.
   const repoAStars = repoA.stargazers ?? 0;
   const repoBStars = repoB.stargazers ?? 0;
@@ -156,28 +249,13 @@ export async function fetchGitHubProjects(): Promise<{
   repos: RepoInfo[];
 }> {
   const rawRepos = await queryRepos();
-  const repos: RepoInfo[] = rawRepos
-    .map(
-      (rawRepo) =>
-        ({
-          stargazers: rawRepo.stargazerCount,
-          watchers: rawRepo.watchers.totalCount,
-          forks: rawRepo.forkCount,
-          license: rawRepo.licenseInfo?.name ?? null,
-          url: rawRepo.url,
-          owner: rawRepo.owner.login,
-          name: rawRepo.name,
-          archived: rawRepo.isArchived,
-          description: rawRepo.description,
-          homepage: rawRepo.homepageUrl,
-          languages: rawRepo.languages?.edges
-            ? Object.fromEntries(
-                rawRepo.languages.edges.map((langInfo) => [langInfo.node.name, langInfo.size]),
-              )
-            : null,
-        }) satisfies RepoInfo,
-    )
-    .sort(sortGitHubRepos);
+
+  const pinnedRepoIds = await queryPinnedRepos();
+  const unsortedRepos = rawRepos.map(
+    (r) => ({ pinned: pinnedRepoIds.has(r.id), ...r }) satisfies RepoInfo,
+  );
+
+  const repos: RepoInfo[] = unsortedRepos.sort(sortGitHubRepos);
 
   const now = DateTime.utc();
   return { timestamp: now.toISO(), repos };


### PR DESCRIPTION
This PR adjusts the Projects page so that pinned repositories are shown first (with a pin icon).

Unfortunately, GitHub's REST API does not provide an endpoint for querying a user's pinned items, so there is no way to identify which repositories are pinned. Such a query can only be done through the GraphQL API. Thus, this PR also changes the queries to use the GraphQL API.